### PR TITLE
Add support for new-ish levels type list view

### DIFF
--- a/src/schemas/api.ts
+++ b/src/schemas/api.ts
@@ -5,7 +5,7 @@ import { FieldMetadataSchema } from './fields'
 export const ViewMetadataSchema = z.object({
   id: z.string(),
   name: z.string(),
-  type: z.enum(['grid', 'form', 'calendar', 'gallery', 'kanban', 'block', 'levels', 'timeline']),
+  type: z.enum(['grid', 'form', 'calendar', 'gallery', 'kanban', 'block', 'levels', 'timeline', 'levels']),
 })
 export type ViewMetadata = z.infer<typeof ViewMetadataSchema>
 

--- a/test/fixtures/api/tables-meta.json
+++ b/test/fixtures/api/tables-meta.json
@@ -504,6 +504,11 @@
           "id": "viwtqpPEMVOvQOq9u",
           "name": "Just office furniture",
           "type": "grid"
+        },
+        {
+          "id": "viwvLENagZ198820w",
+          "name": "Furniture sets",
+          "type": "levels"
         }
       ]
     },
@@ -628,10 +633,7 @@
           "type": "formula",
           "options": {
             "isValid": true,
-            "referencedFieldIds": [
-              "fldPvpKkpn17F1Wzg",
-              "fldNvvsZK8Ms6gbND"
-            ],
+            "referencedFieldIds": ["fldPvpKkpn17F1Wzg", "fldNvvsZK8Ms6gbND"],
             "result": {
               "type": "singleLineText"
             }
@@ -771,11 +773,7 @@
           "type": "formula",
           "options": {
             "isValid": true,
-            "referencedFieldIds": [
-              "fld3qxtb8vwp07wS6",
-              "fldKtxaK0raVsXY1k",
-              "fldVoviWYw1Xn8Z2k"
-            ],
+            "referencedFieldIds": ["fld3qxtb8vwp07wS6", "fldKtxaK0raVsXY1k", "fldVoviWYw1Xn8Z2k"],
             "result": {
               "type": "singleLineText"
             }
@@ -823,10 +821,7 @@
           "type": "formula",
           "options": {
             "isValid": true,
-            "referencedFieldIds": [
-              "fldLttaHOvaXvZQYq",
-              "fldKtxaK0raVsXY1k"
-            ],
+            "referencedFieldIds": ["fldLttaHOvaXvZQYq", "fldKtxaK0raVsXY1k"],
             "result": {
               "type": "currency",
               "options": {


### PR DESCRIPTION
### What is this?

Airtable bases now support a hierarchical "list" view for parent child relationships, allowing a cascading to-do list sort of UI. Neat!

This new view has a type of "levels", which _offends_ the Zod Schema `ViewMetadataSchema`

### And so?

This patch adds the `levels` type to the Zod schema, and includes a mock view type in test fixture.